### PR TITLE
ADD: Remote control via Socket.IO

### DIFF
--- a/app.py
+++ b/app.py
@@ -526,8 +526,7 @@ def setup_remote_host(remote_host):
         except TypeError:
             pass
 
-    @sio.on("to_neuronavigation")
-    def handler(msg):
+    def to_neuronavigation(msg):
         topic = msg["topic"]
         data = msg["data"]
 
@@ -536,6 +535,13 @@ def setup_remote_host(remote_host):
             topicName=topic,
             **data
         )
+
+    @sio.on("to_neuronavigation")
+    def to_neuronavigation_wrapper(msg):
+
+        # wx.CallAfter wrapping is needed to make messages that update WxPython UI work properly, as the
+        # Socket.IO listener runs inside a thread. (See WxPython and thread-safety for more information.)
+        wx.CallAfter(to_neuronavigation, msg)
 
     Publisher.add_sendMessage_hook(emit)
 

--- a/app.py
+++ b/app.py
@@ -529,6 +529,8 @@ def setup_remote_host(remote_host):
     def to_neuronavigation(msg):
         topic = msg["topic"]
         data = msg["data"]
+        if data is None:
+            data = {}
 
         print("Received an event into topic '{}' with data {}".format(topic, str(data)))
         Publisher.sendMessage_no_hook(

--- a/app.py
+++ b/app.py
@@ -25,6 +25,7 @@ import optparse as op
 import os
 import sys
 import shutil
+import time
 import traceback
 
 import re
@@ -51,7 +52,7 @@ try:
 except ImportError:
     from wx import SplashScreen
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 #import wx.lib.agw.advancedsplash as agw
 #if sys.platform.startswith('linux'):
@@ -322,6 +323,10 @@ def parse_comand_line():
 
     parser.add_option("--import-folder", action="store", dest="import_folder")
 
+    parser.add_option("--remote-host",
+                      action="store",
+                      dest="remote_host")
+
     parser.add_option("-s", "--save",
                       help="Save the project after an import.")
 
@@ -487,11 +492,61 @@ def print_events(topic=Publisher.AUTO_TOPIC, **msg_data):
     """
     utils.debug("%s\n\tParameters: %s" % (topic, msg_data))
 
+def setup_remote_host(remote_host):
+    import socketio
+    sio = socketio.Client()
+
+    connected = False
+
+    @sio.on('connect')
+    def on_connect():
+        print("Connected to {}".format(remote_host))
+
+        nonlocal connected
+        connected = True
+
+    @sio.on('disconnect')
+    def on_disconnect():
+        print("Disconnected")
+
+    sio.connect(remote_host)
+
+    while not connected:
+        print("Connecting...")
+        time.sleep(1.0)
+
+    def emit(topic, data):
+        print("Emitting data {} to topic {}".format(data, topic))
+        try:
+            if isinstance(topic, str):
+                sio.emit("from_neuronavigation", {
+                    "topic": topic,
+                    "data": data,
+                })
+        except TypeError:
+            pass
+
+    @sio.on("to_neuronavigation")
+    def handler(msg):
+        topic = msg["topic"]
+        data = msg["data"]
+
+        print("Received an event into topic '{}' with data {}".format(topic, str(data)))
+        Publisher.sendMessage_no_hook(
+            topicName=topic,
+            **data
+        )
+
+    Publisher.add_sendMessage_hook(emit)
+
 def main():
     """
     Initialize InVesalius GUI
     """
     options, args = parse_comand_line()
+
+    if options.remote_host is not None:
+        setup_remote_host(options.remote_host)
 
     if options.no_gui:
         non_gui_startup(options, args)

--- a/docs/devel/example_pubsub.py
+++ b/docs/devel/example_pubsub.py
@@ -3,7 +3,7 @@
 # More information about this design pattern can be found at:
 # http://wiki.wxpython.org/ModelViewController
 # http://wiki.wxpython.org/PubSub
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 # The maintainer of Pubsub module is Oliver Schoenborn.
 # Since the end of 2006 Pubsub is now maintained separately on SourceForge at:

--- a/docs/devel/example_singleton_pubsub.py
+++ b/docs/devel/example_singleton_pubsub.py
@@ -1,6 +1,6 @@
 # Singleton and Publisher-Subscriber design patterns example.
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 class Singleton(type):
     # This is a Gary Robinson implementation:

--- a/invesalius/constants.py
+++ b/invesalius/constants.py
@@ -666,8 +666,9 @@ ISOTRAKII = 3
 PATRIOT = 4
 CAMERA = 5
 POLARIS = 6
-DEBUGTRACK = 7
-DISCTRACK = 8
+OPTITRACK = 7
+DEBUGTRACK = 8
+DISCTRACK = 9
 DEFAULT_TRACKER = SELECT
 
 NDICOMPORT = b'COM1'
@@ -675,7 +676,7 @@ NDICOMPORT = b'COM1'
 TRACKER = [_("Select tracker:"), _("Claron MicronTracker"),
            _("Polhemus FASTRAK"), _("Polhemus ISOTRAK II"),
            _("Polhemus PATRIOT"), _("Camera tracker"),
-           _("NDI Polaris"), _("Debug tracker"), _("Disconnect tracker")]
+           _("NDI Polaris"), _("Optitrack"), _("Debug tracker"), _("Disconnect tracker")]
 
 STATIC_REF = 0
 DYNAMIC_REF = 1
@@ -753,7 +754,7 @@ PEEL_DEPTH = 5
 MAX_PEEL_DEPTH = 30
 SEED_OFFSET = 15
 SEED_RADIUS = 1.5
-SLEEP_NAVIGATION = 0.3
+SLEEP_NAVIGATION = 0.1
 BRAIN_OPACITY = 0.5
 N_CPU = psutil.cpu_count()
 TREKKER_CONFIG = {'seed_max': 1, 'step_size': 0.1, 'min_fod': 0.1, 'probe_quality': 3,

--- a/invesalius/constants.py
+++ b/invesalius/constants.py
@@ -28,7 +28,7 @@ from invesalius import utils
 from invesalius import inv_paths
 
 #from invesalius.project import Project
-INVESALIUS_VERSION = "3.1.99994"
+INVESALIUS_VERSION = "3.1.99995"
 
 INVESALIUS_ACTUAL_FORMAT_VERSION = 1.1
 

--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -24,7 +24,7 @@ import textwrap
 import wx
 import numpy as np
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.data.imagedata_utils as image_utils

--- a/invesalius/control.py
+++ b/invesalius/control.py
@@ -1085,7 +1085,7 @@ class Controller():
                 if not os.path.isfile(path):
                     path = os.path.join(inv_paths.USER_RAYCASTING_PRESETS_DIRECTORY,
                                     preset_name+".plist")
-            with open(path, 'r+b') as f:
+            with open(path, 'rb') as f:
                 preset = plistlib.load(f, fmt=plistlib.FMT_XML)
             prj.Project().raycasting_preset = preset
             # Notify volume

--- a/invesalius/data/coordinates.py
+++ b/invesalius/data/coordinates.py
@@ -26,7 +26,7 @@ import invesalius.constants as const
 
 from time import sleep
 from random import uniform
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 
 def GetCoordinates(trck_init, trck_id, ref_mode):

--- a/invesalius/data/editor.py
+++ b/invesalius/data/editor.py
@@ -18,7 +18,7 @@
 #--------------------------------------------------------------------------
 
 import math
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 import vtk
 
 AXIAL = 2

--- a/invesalius/data/geometry.py
+++ b/invesalius/data/geometry.py
@@ -22,7 +22,7 @@ import math
 
 import numpy as np
 import vtk
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.utils as utils

--- a/invesalius/data/imagedata_utils.py
+++ b/invesalius/data/imagedata_utils.py
@@ -27,7 +27,8 @@ import imageio
 import numpy
 import numpy as np
 import vtk
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
+
 from scipy.ndimage import shift, zoom
 from vtk.util import numpy_support
 

--- a/invesalius/data/mask.py
+++ b/invesalius/data/mask.py
@@ -33,7 +33,7 @@ from invesalius.data.volume import VolumeMask
 import numpy as np
 import vtk
 from invesalius_cy import floodfill
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 from scipy import ndimage
 from vtk.util import numpy_support
 

--- a/invesalius/data/measures.py
+++ b/invesalius/data/measures.py
@@ -4,7 +4,7 @@ import math
 import random
 import sys
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import numpy as np
 import vtk

--- a/invesalius/data/polydata_utils.py
+++ b/invesalius/data/polydata_utils.py
@@ -21,7 +21,7 @@ import sys
 
 import vtk
 import wx
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.data.vtk_utils as vu

--- a/invesalius/data/record_coords.py
+++ b/invesalius/data/record_coords.py
@@ -23,7 +23,7 @@ import time
 import wx
 from numpy import array, savetxt, hstack,vstack, asarray
 import invesalius.gui.dialogs as dlg
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 
 class Record(threading.Thread):

--- a/invesalius/data/slice_.py
+++ b/invesalius/data/slice_.py
@@ -381,7 +381,6 @@ class Slice(metaclass=utils.Singleton):
             return
         proj = Project()
         index = proj.mask_dict.get_key(self.current_mask)
-        print(f"\n\n\n{index=}\n\n\n")
         self.num_gradient += 1
         self.current_mask.matrix[:] = 0
         self.current_mask.clear_history()

--- a/invesalius/data/slice_.py
+++ b/invesalius/data/slice_.py
@@ -22,7 +22,7 @@ import tempfile
 import numpy as np
 import vtk
 from scipy import ndimage
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.data.converters as converters

--- a/invesalius/data/styles.py
+++ b/invesalius/data/styles.py
@@ -31,7 +31,7 @@ from scipy import ndimage
 from imageio import imsave
 from scipy.ndimage import generate_binary_structure, watershed_ift
 from skimage.morphology import watershed
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.data.converters as converters

--- a/invesalius/data/styles_3d.py
+++ b/invesalius/data/styles_3d.py
@@ -23,7 +23,7 @@ import wx
 import invesalius.constants as const
 import invesalius.project as prj
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 
 PROP_MEASURE = 0.8

--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -38,7 +38,7 @@ import vtk
 import wx
 import wx.lib.agw.genericmessagedialog as GMD
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 if sys.platform == 'win32':
     try:

--- a/invesalius/data/surface.py
+++ b/invesalius/data/surface.py
@@ -609,6 +609,9 @@ class SurfaceManager():
         """
         Create surface actor, save into project and send it to viewer.
         """
+        if mask.matrix.max() < 127:
+            wx.MessageBox(_("It's not possible to create a surface because there is not any voxel selected on mask"), _("Create surface warning"))
+            return
         t_init = time.time()
         matrix = slice_.matrix
         filename_img = slice_.matrix_filename

--- a/invesalius/data/trackers.py
+++ b/invesalius/data/trackers.py
@@ -40,6 +40,7 @@ def TrackerConnection(tracker_id, trck_init, action):
                     const.PATRIOT: PolhemusTracker,    # PATRIOT
                     const.CAMERA: CameraTracker,      # CAMERA
                     const.POLARIS: PolarisTracker,      # POLARIS
+                    const.OPTITRACK: OptitrackTracker,   #Optitrack
                     const.DEBUGTRACK: DebugTracker}
 
         trck_init = trck_fcn[tracker_id](tracker_id)
@@ -62,6 +63,30 @@ def DefaultTracker(tracker_id):
     # return tracker initialization variable and type of connection
     return trck_init, 'wrapper'
 
+def OptitrackTracker(tracker_id):
+    """
+    Imports optitrack wrapper from Motive 2.2. Initialize cameras, attach listener, loads Calibration, loads User Profile
+    (Rigid bodies information).
+
+    Parameters
+    ----------
+    tracker_id : Optitrack ID
+
+    Returns
+    -------
+    trck_init : local name for Optitrack module
+    """
+    trck_init = None
+    try:
+        import optitrack
+        trck_init = optitrack.optr()
+        if trck_init.Initialize()==0:
+            trck_init.Run() #Runs once Run function, to update cameras.
+        else:
+            trck_init = None
+    except ImportError:
+        print('Error')
+    return trck_init, 'wrapper'
 
 def PolarisTracker(tracker_id):
     from wx import ID_OK

--- a/invesalius/data/tractography.py
+++ b/invesalius/data/tractography.py
@@ -28,7 +28,7 @@ import time
 
 import numpy as np
 import queue
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 from scipy.stats import norm
 import vtk
 

--- a/invesalius/data/trigger.py
+++ b/invesalius/data/trigger.py
@@ -21,7 +21,7 @@ import threading
 from time import sleep
 
 import wx
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 
 class Trigger(threading.Thread):

--- a/invesalius/data/viewer_slice.py
+++ b/invesalius/data/viewer_slice.py
@@ -31,7 +31,7 @@ from vtk.wx.wxVTKRenderWindowInteractor import wxVTKRenderWindowInteractor
 import invesalius.data.styles as styles
 import wx
 import sys
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 try:
     from agw import floatspin as FS

--- a/invesalius/data/viewer_volume.py
+++ b/invesalius/data/viewer_volume.py
@@ -29,7 +29,7 @@ from numpy.core.umath_tests import inner1d
 import wx
 import vtk
 from vtk.wx.wxVTKRenderWindowInteractor import wxVTKRenderWindowInteractor
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 import random
 from scipy.spatial import distance
 
@@ -589,6 +589,7 @@ class Viewer(wx.Panel):
 
         self.ren.AddActor(self.staticballs[self.ball_id])
         self.ball_id = self.ball_id + 1
+
         #self.UpdateRender()
         self.Refresh()
 

--- a/invesalius/data/volume.py
+++ b/invesalius/data/volume.py
@@ -24,7 +24,7 @@ from distutils.version import LooseVersion
 import numpy
 import vtk
 import wx
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.project as prj

--- a/invesalius/data/volume.py
+++ b/invesalius/data/volume.py
@@ -356,7 +356,7 @@ class Volume():
         if color_preset != "No CLUT":
             path = os.path.join(inv_paths.RAYCASTING_PRESETS_DIRECTORY,
                                 'color_list', color_preset + '.plist')
-            with open(path, 'r+b') as f:
+            with open(path, 'rb') as f:
                 p = plistlib.load(f, fmt=plistlib.FMT_XML)
 
             r = p['Red']

--- a/invesalius/data/vtk_utils.py
+++ b/invesalius/data/vtk_utils.py
@@ -219,6 +219,8 @@ class TextZero(object):
         self.text = ''
         self.position = (0, 0)
         self.symbolic_syze = wx.FONTSIZE_MEDIUM
+        self.bottom_pos = False
+        self.right_pos = False
 
     def SetColour(self, colour):
         self.property.SetColor(colour)
@@ -282,10 +284,15 @@ class TextZero(object):
         coord.SetCoordinateSystemToNormalizedDisplay()
         coord.SetValue(*self.position)
         x, y = coord.GetComputedDisplayValue(canvas.evt_renderer)
-
         font = wx.SystemSettings.GetFont(wx.SYS_DEFAULT_GUI_FONT)
         #  font.SetWeight(wx.FONTWEIGHT_BOLD)
         font.SetSymbolicSize(self.symbolic_syze)
+        if self.bottom_pos or self.right_pos:
+            w, h = canvas.calc_text_size(self.text, font)
+            if self.right_pos:
+                x -= w
+            if self.bottom_pos:
+                y += h
         canvas.draw_text(self.text, (x, y), font=font)
 
 

--- a/invesalius/data/vtk_utils.py
+++ b/invesalius/data/vtk_utils.py
@@ -46,7 +46,7 @@ def ShowProgress(number_of_filters = 1,
     if (dialog_type == "ProgressDialog"):
         try:
             dlg = ProgressDialog(wx.GetApp().GetTopWindow(), 100)
-        except wx._core.PyNoAppError:
+        except (wx._core.PyNoAppError, AttributeError):
             return lambda obj, label: 0
 
 

--- a/invesalius/data/vtk_utils.py
+++ b/invesalius/data/vtk_utils.py
@@ -20,7 +20,7 @@ import sys
 
 import vtk
 import wx
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 import invesalius.constants as const
 from invesalius.gui.dialogs import ProgressDialog
 

--- a/invesalius/gui/bitmap_preview_panel.py
+++ b/invesalius/gui/bitmap_preview_panel.py
@@ -5,7 +5,7 @@ import numpy
 
 from vtk.util import  numpy_support
 from vtk.wx.wxVTKRenderWindowInteractor import wxVTKRenderWindowInteractor
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.data.vtk_utils as vtku

--- a/invesalius/gui/bitmap_preview_panel.py
+++ b/invesalius/gui/bitmap_preview_panel.py
@@ -12,6 +12,7 @@ import invesalius.data.vtk_utils as vtku
 import invesalius.data.converters as converters
 import invesalius.reader.bitmap_reader as bitmap_reader
 import invesalius.utils as utils
+from invesalius.gui.widgets.canvas_renderer import CanvasRendererCTX
 
 NROWS = 3
 NCOLS = 6
@@ -447,53 +448,68 @@ class SingleImagePreview(wx.Panel):
         self.window_level = const.WINDOW_LEVEL[_("Bone")][1]
 
     def __init_vtk(self):
-        text_image_size = vtku.Text()
+        text_image_size = vtku.TextZero()
         text_image_size.SetPosition(const.TEXT_POS_LEFT_UP)
         text_image_size.SetValue("")
-        text_image_size.SetSize(const.TEXT_SIZE_SMALL)
+        text_image_size.SetSymbolicSize(wx.FONTSIZE_SMALL)
         self.text_image_size = text_image_size
 
-        text_image_location = vtku.Text()
-        text_image_location.SetVerticalJustificationToBottom()
+        text_image_location = vtku.TextZero()
+        #  text_image_location.SetVerticalJustificationToBottom()
         text_image_location.SetPosition(const.TEXT_POS_LEFT_DOWN)
         text_image_location.SetValue("")
-        text_image_location.SetSize(const.TEXT_SIZE_SMALL)
+        text_image_location.bottom_pos = True
+        text_image_location.SetSymbolicSize(wx.FONTSIZE_SMALL)
         self.text_image_location = text_image_location
 
-        text_patient = vtku.Text()
-        text_patient.SetJustificationToRight()
+        text_patient = vtku.TextZero()
+        #  text_patient.SetJustificationToRight()
         text_patient.SetPosition(const.TEXT_POS_RIGHT_UP)
         text_patient.SetValue("")
-        text_patient.SetSize(const.TEXT_SIZE_SMALL)
+        text_patient.right_pos = True
+        text_patient.SetSymbolicSize(wx.FONTSIZE_SMALL)
         self.text_patient = text_patient
 
-        text_acquisition = vtku.Text()
-        text_acquisition.SetJustificationToRight()
-        text_acquisition.SetVerticalJustificationToBottom()
+        text_acquisition = vtku.TextZero()
+        #  text_acquisition.SetJustificationToRight()
+        #  text_acquisition.SetVerticalJustificationToBottom()
         text_acquisition.SetPosition(const.TEXT_POS_RIGHT_DOWN)
         text_acquisition.SetValue("")
-        text_acquisition.SetSize(const.TEXT_SIZE_SMALL)
+        text_acquisition.right_pos = True
+        text_acquisition.bottom_pos = True
+        text_acquisition.SetSymbolicSize(wx.FONTSIZE_SMALL)
         self.text_acquisition = text_acquisition
 
-        renderer = vtk.vtkRenderer()
-        renderer.AddActor(text_image_size.actor)
-        renderer.AddActor(text_image_location.actor)
-        renderer.AddActor(text_patient.actor)
-        renderer.AddActor(text_acquisition.actor)
-        self.renderer = renderer
+        self.renderer = vtk.vtkRenderer()
+        self.renderer.SetLayer(0)
+
+        cam = self.renderer.GetActiveCamera()
+
+        self.canvas_renderer = vtk.vtkRenderer()
+        self.canvas_renderer.SetLayer(1)
+        self.canvas_renderer.SetActiveCamera(cam)
+        self.canvas_renderer.SetInteractive(0)
+        self.canvas_renderer.PreserveDepthBufferOn()
 
         style = vtk.vtkInteractorStyleImage()
 
-        interactor = wxVTKRenderWindowInteractor(self.panel, -1,
-                                    size=wx.Size(340,340))
-        interactor.SetRenderWhenDisabled(True)
-        interactor.GetRenderWindow().AddRenderer(renderer)
-        interactor.SetInteractorStyle(style)
-        interactor.Render()
-        self.interactor = interactor
+        self.interactor = wxVTKRenderWindowInteractor(self.panel, -1,
+                                                      size=wx.Size(340,340))
+        self.interactor.SetRenderWhenDisabled(True)
+        self.interactor.GetRenderWindow().SetNumberOfLayers(2)
+        self.interactor.GetRenderWindow().AddRenderer(self.renderer)
+        self.interactor.GetRenderWindow().AddRenderer(self.canvas_renderer)
+        self.interactor.SetInteractorStyle(style)
+        self.interactor.Render()
+
+        self.canvas = CanvasRendererCTX(self, self.renderer, self.canvas_renderer)
+        self.canvas.draw_list.append(self.text_image_size)
+        self.canvas.draw_list.append(self.text_image_location)
+        self.canvas.draw_list.append(self.text_patient)
+        self.canvas.draw_list.append(self.text_acquisition)
 
         sizer = wx.BoxSizer(wx.VERTICAL)
-        sizer.Add(interactor, 1, wx.GROW|wx.EXPAND)
+        sizer.Add(self.interactor, 1, wx.GROW|wx.EXPAND)
         sizer.Fit(self.panel)
         self.panel.SetSizer(sizer)
         self.Layout()

--- a/invesalius/gui/brain_seg_dialog.py
+++ b/invesalius/gui/brain_seg_dialog.py
@@ -12,7 +12,7 @@ import time
 
 import numpy as np
 import wx
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.data.slice_ as slc
 from invesalius.segmentation.brain import segment, utils

--- a/invesalius/gui/brain_seg_dialog.py
+++ b/invesalius/gui/brain_seg_dialog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
 import importlib

--- a/invesalius/gui/data_notebook.py
+++ b/invesalius/gui/data_notebook.py
@@ -34,7 +34,7 @@ except ImportError:
     import wx.lib.flatnotebook as fnb
 
 import wx.lib.platebtn as pbtn
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.data.slice_ as slice_

--- a/invesalius/gui/default_tasks.py
+++ b/invesalius/gui/default_tasks.py
@@ -22,7 +22,7 @@ try:
     import wx.lib.agw.foldpanelbar as fpb
 except ModuleNotFoundError:
     import wx.lib.foldpanelbar as fpb
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.gui.data_notebook as nb

--- a/invesalius/gui/default_viewers.py
+++ b/invesalius/gui/default_viewers.py
@@ -21,7 +21,7 @@ import os
 
 import wx
 import wx.lib.agw.fourwaysplitter as fws
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.data.viewer_slice as slice_viewer
 import invesalius.data.viewer_volume as volume_viewer
@@ -316,7 +316,7 @@ class VolumeInteraction(wx.Panel):
 
 import wx.lib.platebtn as pbtn
 import wx.lib.buttons as btn
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 import wx.lib.colourselect as csel
 
 RAYCASTING_TOOLS = wx.NewId()

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -869,6 +869,7 @@ def ShowNavigationTrackerWarning(trck_id, lib_mode):
             const.PATRIOT: 'Polhemus PATRIOT',
             const.CAMERA: 'CAMERA',
             const.POLARIS: 'NDI Polaris',
+            const.OPTITRACK: 'Optitrack',
             const.DEBUGTRACK: 'Debug tracker device'}
 
     if lib_mode == 'choose':

--- a/invesalius/gui/dialogs.py
+++ b/invesalius/gui/dialogs.py
@@ -47,7 +47,7 @@ from vtk.wx.wxVTKRenderWindowInteractor import wxVTKRenderWindowInteractor
 from wx.lib import masked
 from wx.lib.agw import floatspin
 from wx.lib.wordwrap import wordwrap
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 try:
     from wx.adv import AboutDialogInfo, AboutBox

--- a/invesalius/gui/dicom_preview_panel.py
+++ b/invesalius/gui/dicom_preview_panel.py
@@ -29,7 +29,7 @@ import vtk
 
 from vtk.util import  numpy_support
 from vtk.wx.wxVTKRenderWindowInteractor import wxVTKRenderWindowInteractor
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.reader.dicom_reader as dicom_reader

--- a/invesalius/gui/dicom_preview_panel.py
+++ b/invesalius/gui/dicom_preview_panel.py
@@ -37,6 +37,7 @@ import invesalius.data.vtk_utils as vtku
 import invesalius.utils as utils
 from invesalius.data import imagedata_utils
 from invesalius.data import converters
+from invesalius.gui.widgets.canvas_renderer import CanvasRendererCTX
 
 if sys.platform == 'win32':
     try:
@@ -716,46 +717,62 @@ class SingleImagePreview(wx.Panel):
         self.window_level = const.WINDOW_LEVEL[_("Bone")][1]
 
     def __init_vtk(self):
-        text_image_size = vtku.Text()
+        text_image_size = vtku.TextZero()
         text_image_size.SetPosition(const.TEXT_POS_LEFT_UP)
         text_image_size.SetValue("")
-        text_image_size.SetSize(const.TEXT_SIZE_SMALL)
+        text_image_size.SetSymbolicSize(wx.FONTSIZE_SMALL)
         self.text_image_size = text_image_size
 
-        text_image_location = vtku.Text()
-        text_image_location.SetVerticalJustificationToBottom()
+        text_image_location = vtku.TextZero()
+        #  text_image_location.SetVerticalJustificationToBottom()
         text_image_location.SetPosition(const.TEXT_POS_LEFT_DOWN)
         text_image_location.SetValue("")
-        text_image_location.SetSize(const.TEXT_SIZE_SMALL)
+        text_image_location.bottom_pos = True
+        text_image_location.SetSymbolicSize(wx.FONTSIZE_SMALL)
         self.text_image_location = text_image_location
 
-        text_patient = vtku.Text()
-        text_patient.SetJustificationToRight()
+        text_patient = vtku.TextZero()
+        #  text_patient.SetJustificationToRight()
         text_patient.SetPosition(const.TEXT_POS_RIGHT_UP)
         text_patient.SetValue("")
-        text_patient.SetSize(const.TEXT_SIZE_SMALL)
+        text_patient.right_pos = True
+        text_patient.SetSymbolicSize(wx.FONTSIZE_SMALL)
         self.text_patient = text_patient
 
-        text_acquisition = vtku.Text()
-        text_acquisition.SetJustificationToRight()
-        text_acquisition.SetVerticalJustificationToBottom()
+        text_acquisition = vtku.TextZero()
+        #  text_acquisition.SetJustificationToRight()
+        #  text_acquisition.SetVerticalJustificationToBottom()
         text_acquisition.SetPosition(const.TEXT_POS_RIGHT_DOWN)
         text_acquisition.SetValue("")
-        text_acquisition.SetSize(const.TEXT_SIZE_SMALL)
+        text_acquisition.right_pos = True
+        text_acquisition.bottom_pos = True
+        text_acquisition.SetSymbolicSize(wx.FONTSIZE_SMALL)
         self.text_acquisition = text_acquisition
 
-        renderer = vtk.vtkRenderer()
-        renderer.AddActor(text_image_size.actor)
-        renderer.AddActor(text_image_location.actor)
-        renderer.AddActor(text_patient.actor)
-        renderer.AddActor(text_acquisition.actor)
-        self.renderer = renderer
+        self.renderer = vtk.vtkRenderer()
+        self.renderer.SetLayer(0)
+
+        cam = self.renderer.GetActiveCamera()
+
+        self.canvas_renderer = vtk.vtkRenderer()
+        self.canvas_renderer.SetLayer(1)
+        self.canvas_renderer.SetActiveCamera(cam)
+        self.canvas_renderer.SetInteractive(0)
+        self.canvas_renderer.PreserveDepthBufferOn()
 
         style = vtk.vtkInteractorStyleImage()
 
-        self.interactor.GetRenderWindow().AddRenderer(renderer)
+        self.interactor.GetRenderWindow().SetNumberOfLayers(2)
+        self.interactor.GetRenderWindow().AddRenderer(self.renderer)
+        self.interactor.GetRenderWindow().AddRenderer(self.canvas_renderer)
         self.interactor.SetInteractorStyle(style)
         self.interactor.Render()
+
+        self.canvas = CanvasRendererCTX(self, self.renderer, self.canvas_renderer)
+        self.canvas.draw_list.append(self.text_image_size)
+        self.canvas.draw_list.append(self.text_image_location)
+        self.canvas.draw_list.append(self.text_patient)
+        self.canvas.draw_list.append(self.text_acquisition)
 
     def __init_gui(self):
         slider = wx.Slider(self,

--- a/invesalius/gui/dicom_preview_panel.py
+++ b/invesalius/gui/dicom_preview_panel.py
@@ -908,7 +908,6 @@ class SingleImagePreview(wx.Panel):
                 filename = win32api.GetShortPathName(filename).encode(const.FS_ENCODE)
 
             np_image = imagedata_utils.read_dcm_slice_as_np2(filename)
-            print(">>> spacing", dicom.image.spacing)
             vtk_image = converters.to_vtk(np_image, dicom.image.spacing, 0, 'AXIAL')
 
             # ADJUST CONTRAST
@@ -932,6 +931,8 @@ class SingleImagePreview(wx.Panel):
         if self.actor is None:
             self.actor = vtk.vtkImageActor()
             self.renderer.AddActor(self.actor)
+
+        self.canvas.modified = True
 
         # PLOT IMAGE INTO VIEWER
         self.actor.SetInputData(flip.GetOutput())

--- a/invesalius/gui/frame.py
+++ b/invesalius/gui/frame.py
@@ -43,7 +43,7 @@ import wx.lib.popupctl as pc
 from invesalius import inv_paths
 from invesalius.gui import project_properties
 from wx.lib.agw.aui.auibar import AUI_TB_PLAIN_BACKGROUND, AuiToolBar
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 try:
     from wx.adv import TaskBarIcon as wx_TaskBarIcon

--- a/invesalius/gui/import_bitmap_panel.py
+++ b/invesalius/gui/import_bitmap_panel.py
@@ -18,7 +18,7 @@
 #--------------------------------------------------------------------------
 import wx
 import wx.gizmos as gizmos
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 import wx.lib.splitter as spl
 
 import invesalius.constants as const

--- a/invesalius/gui/import_network_panel.py
+++ b/invesalius/gui/import_network_panel.py
@@ -19,7 +19,7 @@
 import wx
 import sys
 import wx.gizmos as gizmos
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 import wx.lib.splitter as spl
 
 import invesalius.constants as const

--- a/invesalius/gui/import_panel.py
+++ b/invesalius/gui/import_panel.py
@@ -18,7 +18,7 @@
 #--------------------------------------------------------------------------
 import wx
 import wx.gizmos as gizmos
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 import wx.lib.splitter as spl
 
 import invesalius.constants as const

--- a/invesalius/gui/language_dialog.py
+++ b/invesalius/gui/language_dialog.py
@@ -54,7 +54,7 @@ class ComboBoxLanguage:
         self.locales = sorted(self.locales)
        
         # Retrieve locales keys (eg: pt_BR for Portuguese(Brazilian))
-        self.locales_key = [dict_locales.get_key(value)[0] for value in self.locales]
+        self.locales_key = [dict_locales.get_key(value) for value in self.locales]
 
         # Find out OS locale
         self.os_locale = i18n.GetLocaleOS()

--- a/invesalius/gui/language_dialog.py
+++ b/invesalius/gui/language_dialog.py
@@ -1,10 +1,10 @@
-#--------------------------------------------------------------------------
+# --------------------------------------------------------------------------
 # Software:     InVesalius - Software de Reconstrucao 3D de Imagens Medicas
 # Copyright:    (C) 2001  Centro de Pesquisas Renato Archer
 # Homepage:     http://www.softwarepublico.gov.br
 # Contact:      invesalius@cti.gov.br
 # License:      GNU - GPL 2 (LICENSE.txt/LICENCA.txt)
-#--------------------------------------------------------------------------
+# --------------------------------------------------------------------------
 #    Este programa e software livre; voce pode redistribui-lo e/ou
 #    modifica-lo sob os termos da Licenca Publica Geral GNU, conforme
 #    publicada pela Free Software Foundation; de acordo com a versao 2
@@ -15,11 +15,12 @@
 #    COMERCIALIZACAO ou de ADEQUACAO A QUALQUER PROPOSITO EM
 #    PARTICULAR. Consulte a Licenca Publica Geral GNU para obter mais
 #    detalhes.
-#--------------------------------------------------------------------------
+# --------------------------------------------------------------------------
 
 import os
 import sys
 import wx
+
 try:
     from wx.adv import BitmapComboBox
 except ImportError:
@@ -29,49 +30,53 @@ import invesalius.i18n as i18n
 
 file_path = os.path.split(__file__)[0]
 
-if hasattr(sys,"frozen") and (sys.frozen == "windows_exe"\
-                            or sys.frozen == "console_exe"):
-    abs_file_path = os.path.abspath(file_path + os.sep + ".." +\
-                                os.sep + ".." + os.sep + ".." + os.sep + "..")
-    ICON_DIR = os.path.abspath(os.path.join(abs_file_path, 'icons'))
+if hasattr(sys, "frozen") and (
+    sys.frozen == "windows_exe" or sys.frozen == "console_exe"
+):
+    abs_file_path = os.path.abspath(
+        file_path + os.sep + ".." + os.sep + ".." + os.sep + ".." + os.sep + ".."
+    )
+    ICON_DIR = os.path.abspath(os.path.join(abs_file_path, "icons"))
 else:
-    ICON_DIR = os.path.abspath(os.path.join(file_path, '..', '..','icons'))
+    ICON_DIR = os.path.abspath(os.path.join(file_path, "..", "..", "icons"))
 
 # MAC App
 if not os.path.exists(ICON_DIR):
-    ICON_DIR = os.path.abspath(os.path.join(file_path, '..', '..', '..', '..', '..',  'icons'))
+    ICON_DIR = os.path.abspath(
+        os.path.join(file_path, "..", "..", "..", "..", "..", "icons")
+    )
+
 
 class ComboBoxLanguage:
-
     def __init__(self, parent):
         """Initialize combobox bitmap"""
-      
-        # Retrieve locales dictionary 
+
+        # Retrieve locales dictionary
         dict_locales = i18n.GetLocales()
-        
+
         # Retrieve locales names and sort them
         self.locales = dict_locales.values()
         self.locales = sorted(self.locales)
-       
+
         # Retrieve locales keys (eg: pt_BR for Portuguese(Brazilian))
         self.locales_key = [dict_locales.get_key(value) for value in self.locales]
 
         # Find out OS locale
         self.os_locale = i18n.GetLocaleOS()
-       
+
         try:
             os_lang = self.os_locale[0:2]
         except TypeError:
             os_lang = None
 
         # Default selection will be English
-        selection = self.locales_key.index('en')
+        selection = self.locales_key.index("en")
 
         # Create bitmap combo
         self.bitmapCmb = bitmapCmb = BitmapComboBox(parent, style=wx.CB_READONLY)
         for key in self.locales_key:
             # Based on composed flag filename, get bitmap
-            filepath =  os.path.join(ICON_DIR, "%s.png" % (key))
+            filepath = os.path.join(ICON_DIR, "%s.png" % (key))
             bmp = wx.Bitmap(filepath, wx.BITMAP_TYPE_PNG)
             # Add bitmap and info to Combo
             bitmapCmb.Append(dict_locales[key], bmp, key)
@@ -86,6 +91,7 @@ class ComboBoxLanguage:
     def GetLocalesKey(self):
         return self.locales_key
 
+
 class LanguageDialog(wx.Dialog):
     """Class define the language to be used in the InVesalius,
     exist chcLanguage that list language EN and PT. The language
@@ -94,26 +100,26 @@ class LanguageDialog(wx.Dialog):
     def __init__(self, parent=None, startApp=None):
         super(LanguageDialog, self).__init__(parent, title="")
         self.__TranslateMessage__()
-        self.SetTitle(_('Language selection'))
+        self.SetTitle(_("Language selection"))
         self.__init_gui()
         self.Centre()
-        
-    #def __init_combobox_bitmap__(self):
+
+    # def __init_combobox_bitmap__(self):
     #    """Initialize combobox bitmap"""
-      
-    #    # Retrieve locales dictionary 
+
+    #    # Retrieve locales dictionary
     #    dict_locales = i18n.GetLocales()
-        
+
     #    # Retrieve locales names and sort them
     #    self.locales = dict_locales.values()
     #    self.locales.sort()
-       
+
     #    # Retrieve locales keys (eg: pt_BR for Portuguese(Brazilian))
     #    self.locales_key = [dict_locales.get_key(value)[0] for value in self.locales]
 
     #    # Find out OS locale
     #    self.os_locale = i18n.GetLocaleOS()
-       
+
     #    os_lang = self.os_locale[0:2]
 
     #    # Default selection will be English
@@ -135,10 +141,8 @@ class LanguageDialog(wx.Dialog):
     def GetComboBox(self):
         return self.bitmapCmb
 
-
     def __init_gui(self):
-        self.txtMsg = wx.StaticText(self, -1,
-              label=_('Choose user interface language'))
+        self.txtMsg = wx.StaticText(self, -1, label=_("Choose user interface language"))
 
         btnsizer = wx.StdDialogButtonSizer()
 
@@ -150,7 +154,7 @@ class LanguageDialog(wx.Dialog):
         btnsizer.AddButton(btn)
         btnsizer.Realize()
 
-        #self.__init_combobox_bitmap__()
+        # self.__init_combobox_bitmap__()
         self.cmb = ComboBoxLanguage(self)
         self.bitmapCmb = self.cmb.GetComboBox()
 
@@ -174,12 +178,12 @@ class LanguageDialog(wx.Dialog):
         """Translate Messages of the Window"""
         os_language = i18n.GetLocaleOS()
 
-        if(os_language[0:2] == 'pt'):
-            _ = i18n.InstallLanguage('pt_BR')
-        elif(os_language[0:2] == 'es'):
-            _ = i18n.InstallLanguage('es')
+        if os_language[0:2] == "pt":
+            _ = i18n.InstallLanguage("pt_BR")
+        elif os_language[0:2] == "es":
+            _ = i18n.InstallLanguage("es")
         else:
-            _ = i18n.InstallLanguage('en')
+            _ = i18n.InstallLanguage("en")
 
     def Cancel(self, event):
         """Close Frm_Language"""

--- a/invesalius/gui/preferences.py
+++ b/invesalius/gui/preferences.py
@@ -4,7 +4,7 @@ import invesalius.constants as const
 import invesalius.session as ses
 import wx
 from invesalius.gui.language_dialog import ComboBoxLanguage
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 
 class Preferences(wx.Dialog):

--- a/invesalius/gui/project_properties.py
+++ b/invesalius/gui/project_properties.py
@@ -19,7 +19,7 @@
 
 import wx
 import invesalius.project as prj
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 from invesalius.gui import utils
 from invesalius import constants as const
 

--- a/invesalius/gui/task_exporter.py
+++ b/invesalius/gui/task_exporter.py
@@ -29,7 +29,7 @@ except ImportError:
     import wx.lib.hyperlink as hl
 
 import wx.lib.platebtn as pbtn
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.gui.dialogs as dlg

--- a/invesalius/gui/task_importer.py
+++ b/invesalius/gui/task_importer.py
@@ -26,7 +26,7 @@ except ImportError:
     import wx.lib.hyperlink as hl
 import wx.lib.platebtn as pbtn
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.gui.dialogs as dlg

--- a/invesalius/gui/task_navigator.py
+++ b/invesalius/gui/task_navigator.py
@@ -42,7 +42,7 @@ except ImportError:
 
 import wx.lib.colourselect as csel
 import wx.lib.masked.numctrl
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 from time import sleep
 
 import invesalius.constants as const

--- a/invesalius/gui/task_slice.py
+++ b/invesalius/gui/task_slice.py
@@ -31,7 +31,7 @@ except ImportError:
 
 import wx.lib.platebtn as pbtn
 import wx.lib.colourselect as csel
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.data.mask as mask
 import invesalius.data.slice_ as slice_

--- a/invesalius/gui/task_surface.py
+++ b/invesalius/gui/task_surface.py
@@ -28,7 +28,7 @@ except ImportError:
     import wx.lib.hyperlink as hl
     import wx.lib.foldpanelbar as fpb
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 import wx.lib.colourselect as csel
 import wx.lib.scrolledpanel as scrolled
 

--- a/invesalius/gui/task_tools.py
+++ b/invesalius/gui/task_tools.py
@@ -27,7 +27,7 @@ except ImportError:
     import wx.lib.hyperlink as hl
 
 import wx.lib.platebtn as pbtn
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as constants
 import invesalius.constants as const

--- a/invesalius/gui/widgets/canvas_renderer.py
+++ b/invesalius/gui/widgets/canvas_renderer.py
@@ -626,12 +626,12 @@ class CanvasRendererCTX:
             font = wx.SystemSettings.GetFont(wx.SYS_DEFAULT_GUI_FONT)
 
         font = gc.CreateFont(font, txt_colour)
-        gc.SetFont(font)
-
         px, py = pos
         for t in text.split('\n'):
+            t = t.strip()
             _py = -py
             _px = px
+            gc.SetFont(font)
             gc.DrawText(t, _px, _py)
 
             w, h = self.calc_text_size(t)

--- a/invesalius/gui/widgets/canvas_renderer.py
+++ b/invesalius/gui/widgets/canvas_renderer.py
@@ -30,7 +30,7 @@ except ImportError:
     from weakrefmethod import WeakMethod
 
 from invesalius.data import converters
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 
 class CanvasEvent:

--- a/invesalius/gui/widgets/clut_raycasting.py
+++ b/invesalius/gui/widgets/clut_raycasting.py
@@ -24,7 +24,7 @@ import sys
 
 import numpy
 import wx
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.gui.dialogs as dialog
 import invesalius.constants as const

--- a/invesalius/gui/widgets/slice_menu.py
+++ b/invesalius/gui/widgets/slice_menu.py
@@ -26,7 +26,7 @@ except(ImportError):
     from ordereddict import OrderedDict
 
 import wx
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.data.slice_ as sl

--- a/invesalius/gui/widgets/slice_menu.py
+++ b/invesalius/gui/widgets/slice_menu.py
@@ -67,7 +67,7 @@ class SliceMenu(wx.Menu):
         submenu_wl.Append(wl_item)
         self.ID_TO_TOOL_ITEM[new_id] = wl_item
 
-        for name in sorted(const.WINDOW_LEVEL):
+        for name in const.WINDOW_LEVEL:
             if not(name == _('Default') or name == _('Manual')):
                 new_id = wx.NewId()
                 wl_item = wx.MenuItem(submenu_wl, new_id,\

--- a/invesalius/plugins.py
+++ b/invesalius/plugins.py
@@ -24,7 +24,7 @@ import pathlib
 import sys
 from itertools import chain
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as consts
 from invesalius import inv_paths

--- a/invesalius/plugins.py
+++ b/invesalius/plugins.py
@@ -47,11 +47,9 @@ class PluginManager:
 
     def find_plugins(self):
         self.plugins = {}
-        for p in sorted(
-            chain(
-                glob.glob(str(inv_paths.USER_PLUGINS_DIRECTORY.joinpath("**/plugin.json")), recursive=True),
+        for p in chain(
                 glob.glob(str(inv_paths.PLUGIN_DIRECTORY.joinpath("**/plugin.json")), recursive=True),
-            )
+                glob.glob(str(inv_paths.USER_PLUGINS_DIRECTORY.joinpath("**/plugin.json")), recursive=True),
         ):
             try:
                 p = pathlib.Path(p)

--- a/invesalius/presets.py
+++ b/invesalius/presets.py
@@ -155,7 +155,7 @@ class Presets():
                 "Custom":_("Custom")}
 
 
-        with open(filename, 'r+b') as f:
+        with open(filename, 'rb') as f:
             p = plistlib.load(f, fmt=plistlib.FMT_XML)
         thresh_mri = p['thresh_mri'].copy()
         thresh_ct = p['thresh_ct'].copy()
@@ -183,7 +183,7 @@ def get_wwwl_presets():
 
 
 def get_wwwl_preset_colours(pfile):
-    with open(pfile, 'r+b') as f:
+    with open(pfile, 'rb') as f:
         preset = plistlib.load(f, fmt=plistlib.FMT_XML)
     ncolours = len(preset['Blue'])
     colours = []

--- a/invesalius/presets.py
+++ b/invesalius/presets.py
@@ -22,7 +22,7 @@ import plistlib
 
 import invesalius.constants as const
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 from invesalius import inv_paths
 from invesalius.utils import TwoWaysDictionary

--- a/invesalius/project.py
+++ b/invesalius/project.py
@@ -115,6 +115,7 @@ class Project(metaclass=Singleton):
         """
         index = len(self.mask_dict)
         self.mask_dict[index] = mask
+        mask.index = index
         return index
 
     def RemoveMask(self, index):
@@ -126,6 +127,7 @@ class Project(metaclass=Singleton):
                 mask.cleanup()
             else:
                 new_dict[new_index] = self.mask_dict[i]
+                self.mask_dict[i] = new_index
                 new_index += 1
         self.mask_dict = new_dict
 
@@ -338,7 +340,8 @@ class Project(metaclass=Singleton):
             m = msk.Mask()
             m.spacing = self.spacing
             m.OpenPList(filepath)
-            self.mask_dict[int(index)] = m
+            m.index = len(self.mask_dict)
+            self.mask_dict[m.index] = m
 
         # Opening the surfaces
         self.surface_dict = {}

--- a/invesalius/project.py
+++ b/invesalius/project.py
@@ -30,7 +30,7 @@ import numpy as np
 import vtk
 import wx
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.data.polydata_utils as pu

--- a/invesalius/reader/bitmap_reader.py
+++ b/invesalius/reader/bitmap_reader.py
@@ -28,7 +28,7 @@ import numpy
 import vtk
 import wx
 from imageio import imread
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 from vtk.util import numpy_support
 
 import invesalius.constants as const

--- a/invesalius/reader/dicom.py
+++ b/invesalius/reader/dicom.py
@@ -1282,17 +1282,12 @@ class Parser():
         except(KeyError):
             return ""
 
-        if (data):
-            name = data.strip()
-            encoding = self.GetEncoding()
-            
-            try:
-                # Returns a unicode decoded in the own dicom encoding
-                return utils.decode(name, encoding, 'replace')
-            except(UnicodeEncodeError):
-                return name
-
-        return ""
+        encoding = self.GetEncoding()
+        try:
+            data = data.encode(encoding, errors="surrogateescape").decode(encoding)
+        except Exception as err:
+            print(err)
+        return data
 
     def GetPatientID(self):
         """
@@ -1559,13 +1554,20 @@ class Parser():
         """
         try:
             data = self.data_image[str(0x0008)][str(0x103E)]
-            if data == "None":
-                return _("unnamed")
-            if (data):
-                return data
-            else:
-                return _("unnamed")
         except(KeyError):
+            return _("unnamed")
+
+        encoding = self.GetEncoding()
+        try:
+            data = data.encode(encoding, errors="surrogateescape").decode(encoding)
+        except Exception as err:
+            print(err)
+
+        if data == "None":
+            return _("unnamed")
+        if data:
+            return data
+        else:
             return _("unnamed")
 
     def GetImageTime(self):

--- a/invesalius/reader/dicom_grouper.py
+++ b/invesalius/reader/dicom_grouper.py
@@ -131,7 +131,6 @@ class DicomGroup:
             filelist = [dicom.image.file for dicom in
                         self.slices_dict.values()]
 
-        print(f"\n\n\n{filelist=}\n\n\n")
         # Sort slices using GDCM
         #if (self.dicom.image.orientation_label != "CORONAL"):
         #Organize reversed image
@@ -141,7 +140,6 @@ class DicomGroup:
         try:
             sorter.Sort([utils.encode(i, const.FS_ENCODE) for i in filelist])
         except TypeError as e:
-            print(f"\n\n\nError: {e=}\n\n\n")
             sorter.Sort(filelist)
         filelist = sorter.GetFilenames()
 
@@ -149,7 +147,6 @@ class DicomGroup:
         if list(self.slices_dict.values())[0].parser.GetManufacturerName() == "Koning":
             filelist.sort()
 
-        print(f"\n\n\n{filelist=}\n\n\n")
         return filelist
 
     def GetHandSortedList(self):

--- a/invesalius/reader/dicom_reader.py
+++ b/invesalius/reader/dicom_reader.py
@@ -28,7 +28,7 @@ import gdcm
 # Not showing GDCM warning and debug messages
 gdcm.Trace_DebugOff()
 gdcm.Trace_WarningOff()
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 import invesalius.constants as const
 import invesalius.reader.dicom as dicom

--- a/invesalius/session.py
+++ b/invesalius/session.py
@@ -31,7 +31,7 @@ import codecs
 import collections
 import json
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 import wx
 
 from invesalius.utils import Singleton, debug, decode, deep_merge_dict

--- a/invesalius/style.py
+++ b/invesalius/style.py
@@ -17,7 +17,7 @@
 #    detalhes.
 #--------------------------------------------------------------------------
 
-from pubsub import pub as Publisher
+from invesalius_pubsub import pub as Publisher
 
 
 # mode.py

--- a/invesalius_pubsub/pub.py
+++ b/invesalius_pubsub/pub.py
@@ -1,0 +1,86 @@
+#--------------------------------------------------------------------------
+# Software:     InVesalius - Software de Reconstrucao 3D de Imagens Medicas
+# Copyright:    (C) 2001  Centro de Pesquisas Renato Archer
+# Homepage:     http://www.softwarepublico.gov.br
+# Contact:      invesalius@cti.gov.br
+# License:      GNU - GPL 2 (LICENSE.txt/LICENCA.txt)
+#--------------------------------------------------------------------------
+#    Este programa e software livre; voce pode redistribui-lo e/ou
+#    modifica-lo sob os termos da Licenca Publica Geral GNU, conforme
+#    publicada pela Free Software Foundation; de acordo com a versao 2
+#    da Licenca.
+#
+#    Este programa eh distribuido na expectativa de ser util, mas SEM
+#    QUALQUER GARANTIA; sem mesmo a garantia implicita de
+#    COMERCIALIZACAO ou de ADEQUACAO A QUALQUER PROPOSITO EM
+#    PARTICULAR. Consulte a Licenca Publica Geral GNU para obter mais
+#    detalhes.
+#--------------------------------------------------------------------------
+
+from typing import Callable
+
+from pubsub import pub as Publisher
+from pubsub.core.listener import UserListener
+
+__all__ = [
+    # subscribing
+    'subscribe',
+    'unsubscribe',
+
+    # publishing
+    'sendMessage',
+    'sendMessage_no_hook',
+
+    # adding hooks
+    'add_sendMessage_hook'
+]
+
+Hook = Callable[[str, dict], None]
+
+sendMessage_hook: Hook = None
+
+def add_sendMessage_hook(hook: Hook):
+    """Add a hook for sending messages. The hook is a function that takes the topic
+    name as the first parameter and the message dict as the second parameter, and
+    returns None.
+
+    :param hook:
+    """
+    global sendMessage_hook
+    sendMessage_hook = hook
+
+def subscribe(listener: UserListener, topicName: str, **curriedArgs):
+    """Subscribe to a topic.
+
+    :param listener:
+    :param topicName:
+    :param curriedArgs:
+    """
+    subscribedListener, success = Publisher.subscribe(listener, topicName, **curriedArgs)
+    return subscribedListener, success
+
+def unsubscribe(*args, **kwargs):
+    """Unsubscribe from a topic.
+
+    """
+    Publisher.unsubscribe(*args, **kwargs)
+
+def sendMessage(topicName: str, **msgdata):
+    """Send a message in a given topic.
+
+    :param topicName:
+    :param msgdata:
+    """
+    Publisher.sendMessage(topicName, **msgdata)
+    if sendMessage_hook is not None:
+        sendMessage_hook(topicName, msgdata)
+
+def sendMessage_no_hook(topicName: str, **msgdata):
+    """Send a message in a given topic, but do not call the hook.
+
+    :param topicName:
+    :param msgdata:
+    """
+    Publisher.sendMessage(topicName, **msgdata)
+
+AUTO_TOPIC = Publisher.AUTO_TOPIC

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
         "build_ext": build_ext_subclass,
         "build_plugins": BuildPluginsCommand,
     },
+    packages=['invesalius_pubsub'],
     ext_modules=cythonize(
         [
             Extension(


### PR DESCRIPTION
- Add a command line option (--remote-host) to connect to
  a remote server via Socket.IO.

- Add a hook to send all internal events to the remote server using
  `from_neuronavigation` event.

- Add a Socket.IO event listener for `to_neuronavigation` events, send
  publish those events internally.